### PR TITLE
Add python_requires to help pip

### DIFF
--- a/argh/assembling.py
+++ b/argh/assembling.py
@@ -74,13 +74,13 @@ def _get_args_from_signature(function):
     if sys.version_info < (3,0):
         annotations = {}
     else:
-        annotations = dict((k,v) for k,v in function.__annotations__.items()
-                           if isinstance(v, str))
+        annotations = {k:v for k,v in function.__annotations__.items()
+                           if isinstance(v, str)}
 
     # define the list of conflicting option strings
     # (short forms, i.e. single-character ones)
     chars = [a[0] for a in spec.args + kwonly]
-    char_counts = dict((char, chars.count(char)) for char in set(chars))
+    char_counts = {char: chars.count(char) for char in set(chars)}
     conflicting_opts = tuple(char for char in char_counts
                              if 1 < char_counts[char])
 
@@ -97,7 +97,7 @@ def _get_args_from_signature(function):
                 akwargs.update(default=defaults.get(name))
             else:
                 akwargs.update(required=True)
-            flags = ('-{0}'.format(name[0]), '--{0}'.format(name))
+            flags = ('-{}'.format(name[0]), '--{}'.format(name))
             if name.startswith(conflicting_opts):
                 # remove short name
                 flags = flags[1:]

--- a/argh/dispatching.py
+++ b/argh/dispatching.py
@@ -232,8 +232,8 @@ def _execute_command(function, namespace_obj, errors_file, pre_call=None):
         else:
             # namespace -> dictionary
             _flat_key = lambda key: key.replace('-', '_')
-            all_input = dict((_flat_key(k), v)
-                             for k,v in vars(namespace_obj).items())
+            all_input = {_flat_key(k): v
+                             for k,v in vars(namespace_obj).items()}
 
             # filter the namespace variables so that only those expected
             # by the actual function will pass
@@ -242,7 +242,7 @@ def _execute_command(function, namespace_obj, errors_file, pre_call=None):
 
             positional = [all_input[k] for k in spec.args]
             kwonly = getattr(spec, 'kwonlyargs', [])
-            keywords = dict((k, all_input[k]) for k in kwonly)
+            keywords = {k: all_input[k] for k in kwonly}
 
             # *args
             if spec.varargs:
@@ -374,7 +374,7 @@ class EntryPoint(object):
 
     def _dispatch(self):
         if not self.commands:
-            raise DispatchingError('no commands for entry point "{0}"'
+            raise DispatchingError('no commands for entry point "{}"'
                                    .format(self.name))
 
         parser = argparse.ArgumentParser(**self.parser_kwargs)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,6 @@ The `argh` library is supported (and tested unless otherwise specified) on
 the following versions of Python:
 
 * 2.7 (including PyPy 1.8)
-* 3.1 (`argparse` library is required; **not** tested)
 * 3.4
 * 3.5
 * 3.6

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
     install_requires = install_requires,
 
     # testing
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     tests_require = ['pytest', 'mock', 'iocapture'],
     cmdclass = {'test': PyTest},
 

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -112,7 +112,7 @@ def test_simple_function_kwargs():
         # `kwargs` contain all arguments not fitting ArgSpec.args and .varargs.
         # if ArgSpec.keywords in None, all @arg()'s will have to fit ArgSpec.args
         for k in sorted(kwargs):
-            yield '{0}: {1}'.format(k, kwargs[k])
+            yield '{}: {}'.format(k, kwargs[k])
 
     p = DebugArghParser()
     p.set_default_command(cmd)
@@ -149,11 +149,11 @@ def test_all_specs_in_one():
     @argh.arg('fox')
     @argh.arg('--baz')
     def cmd(foo, bar=1, *args, **kwargs):
-        yield 'foo: {0}'.format(foo)
-        yield 'bar: {0}'.format(bar)
-        yield '*args: {0}'.format(args)
+        yield 'foo: {}'.format(foo)
+        yield 'bar: {}'.format(bar)
+        yield '*args: {}'.format(args)
         for k in sorted(kwargs):
-            yield '** {0}: {1}'.format(k, kwargs[k])
+            yield '** {}: {}'.format(k, kwargs[k])
 
     p = DebugArghParser()
     p.set_default_command(cmd)
@@ -330,7 +330,7 @@ class TestErrorWrapping:
 def test_argv():
 
     def echo(text):
-        return 'you said {0}'.format(text)
+        return 'you said {}'.format(text)
 
     p = DebugArghParser()
     p.add_commands([echo])
@@ -426,7 +426,7 @@ def test_echo():
     "A simple command is resolved to a function."
 
     def echo(text):
-        return 'you said {0}'.format(text)
+        return 'you said {}'.format(text)
 
     p = DebugArghParser()
     p.add_commands([echo])
@@ -480,10 +480,10 @@ def test_namespaced_function():
     "A subcommand is resolved to a function."
 
     def hello(name='world'):
-        return 'Hello {0}!'.format(name or 'world')
+        return 'Hello {}!'.format(name or 'world')
 
     def howdy(buddy):
-        return 'Howdy {0}?'.format(buddy)
+        return 'Howdy {}?'.format(buddy)
 
     p = DebugArghParser()
     p.add_commands([hello, howdy], namespace='greet')

--- a/test/test_regressions.py
+++ b/test/test_regressions.py
@@ -17,7 +17,7 @@ def test_regression_issue12():
     """
 
     def cmd(foo=1, fox=2):
-        yield 'foo {0}, fox {1}'.format(foo, fox)
+        yield 'foo {}, fox {}'.format(foo, fox)
 
     p = DebugArghParser()
     p.set_default_command(cmd)
@@ -35,7 +35,7 @@ def test_regression_issue12_help_flag():
     without decorators.
     """
     def ddos(host='localhost'):
-        return 'so be it, {0}!'.format(host)
+        return 'so be it, {}!'.format(host)
 
     # no help → no conflict
     p = DebugArghParser('PROG', add_help=False)
@@ -63,7 +63,7 @@ def test_regression_issue27():
         if count == 3:
             return 'Three shall be the number thou shalt count'
         else:
-            return '{0!r} is right out'.format(count)
+            return '{!r} is right out'.format(count)
 
     p = DebugArghParser()
     p.add_commands([parrot, grenade])


### PR DESCRIPTION
Including dropping support for Python 3.1, which has been EOL and not receiving security updates for over 5.5 years.

This will update your PR https://github.com/neithere/argh/pull/122.